### PR TITLE
Bugfixes and additional feature

### DIFF
--- a/Classes/Builder.php
+++ b/Classes/Builder.php
@@ -105,6 +105,11 @@ class Builder
                     1520906581
                 );
             }
+
+            // $item might comprise arrays of coverAreas and focusArea, too. Those arrays must not be assigned
+            // to the cropVariants, otherwise the crop functionality won't work at all.
+            unset($item['coverAreas'], $item['focusArea']);
+
             $this->cropVariants[$key] = $item;
         }
 

--- a/Classes/Builder.php
+++ b/Classes/Builder.php
@@ -106,10 +106,6 @@ class Builder
                 );
             }
 
-            // $item might comprise arrays of coverAreas and focusArea, too. Those arrays must not be assigned
-            // to the cropVariants, otherwise the crop functionality won't work at all.
-            unset($item['coverAreas'], $item['focusArea']);
-
             $this->cropVariants[$key] = $item;
         }
 

--- a/Classes/CropVariant.php
+++ b/Classes/CropVariant.php
@@ -282,16 +282,23 @@ class CropVariant
             );
         }
 
-        return [
+        $cropVariant = [
             $this->name => [
                 'title' => $this->title,
                 'cropArea' => $this->cropArea,
-                'focusArea' => $this->focusArea,
                 'coverAreas' => $this->coverAreas,
                 'allowedAspectRatios' => $this->allowedAspectRatios,
                 'selectedRatio' => $this->selectedRatio,
             ],
         ];
+
+        // focus area and cover areas are optional. Their key must not be added to the
+        // crop variant, if they have not been configured in CropVariants.yaml
+        if ($this->focusArea) {
+            $cropVariant[$this->name]['focusArea'] = $this->focusArea;
+        }
+
+        return $cropVariant;
     }
 
     /**

--- a/Classes/Defaults/Configuration.php
+++ b/Classes/Defaults/Configuration.php
@@ -62,22 +62,22 @@ class Configuration
         }
 
         // Check if requested key is set in the configuration
-        if (!isset($defaults[trim($key)])) {
+        // focus area and cover area are optional.
+        if ($key !== 'focusAreas' && $key !== 'coverAreas' && !isset($defaults[$key])) {
             throw new \UnexpectedValueException(
                 'Requested key was not found. Is something missing in your configuration file? (Please take a look at ' . self::CONFIGFILE . ')',
                 1524835641
             );
         }
 
-        // Check if requested key is set in the configuration
-        if (empty($defaults[trim($key)])) {
+        if ($key !== 'focusAreas' && $key !== 'coverAreas' && empty($defaults[$key])) {
             throw new \UnexpectedValueException(
                 'Requested key doesn\'t contain any children.  (Please take a look at ' . self::CONFIGFILE . ')',
                 1524835441
             );
         }
 
-        return $defaults[trim($key)];
+        return $defaults[$key] ?? [];
     }
 
     public static function loadYamlFile(string $path): ?array

--- a/Classes/Defaults/CoverArea.php
+++ b/Classes/Defaults/CoverArea.php
@@ -15,13 +15,15 @@ class CoverArea
     {
         $coverAreaPresets = Configuration::defaultConfiguration('coverAreas');
         $coverAreas = [];
-        foreach ($keys as $key => $item) {
-            if (isset($coverAreaPresets[$item]) && \is_array($coverAreaPresets[$item])) {
-                foreach ($coverAreaPresets[$item] as $coverAreaPresetArray) {
-                    $coverAreas[] = $coverAreaPresetArray;
+        if (!empty($coverAreaPresets)) {
+            foreach ($keys as $key => $item) {
+                if (isset($coverAreaPresets[$item]) && \is_array($coverAreaPresets[$item])) {
+                    foreach ($coverAreaPresets[$item] as $coverAreaPresetArray) {
+                        $coverAreas[] = $coverAreaPresetArray;
+                    }
+                } else {
+                    throw new \UnexpectedValueException('Given coverArea preset "' . $key . '" not found or not from type array."', 1520430221);
                 }
-            } else {
-                throw new \UnexpectedValueException('Given coverArea preset "' . $key . '" not found or not from type array."', 1520430221);
             }
         }
         return $coverAreas;

--- a/Classes/Defaults/FocusArea.php
+++ b/Classes/Defaults/FocusArea.php
@@ -11,12 +11,12 @@ class FocusArea
      * @return array focusArea (no default is returned as there is no focusArea necessary)
      * @throws \UnexpectedValueException
      */
-    public static function get(string $name): array
+    public static function get(string $name = 'default'): array
     {
         $focusAreas = Configuration::defaultConfiguration('focusAreas');
         if (isset($focusAreas[$name]) && \is_array($focusAreas[$name])) {
             return $focusAreas[$name];
         }
-        throw new \UnexpectedValueException('Given focus area "' . $name . '" not found."', 1522992127);
+        return [];
     }
 }

--- a/Configuration/ImageManipulation/CropVariants.yaml
+++ b/Configuration/ImageManipulation/CropVariants.yaml
@@ -5,10 +5,11 @@ imageManipulation:
   cropVariants:
     defaults:
 
-
       ##################################################################################################################
       ### Set up your default cropVariants configuration for sys_file_reference.columns.crop
+      ### Ratios mentioned here must be configured in "Available Aspect Ratios" below!
       ###
+      ###     Mandatory configuration!
       ###     Each cropVariant must have a minimum of one aspectRatio
       ###     for sys_file_reference.columns.crop (Look for "persistToDefaultTableTca")
       ###
@@ -21,9 +22,15 @@ imageManipulation:
             - "3:4"
             - "1:1"
             - "NaN"
+        mobile:
+          aspectRatios:
+            - "1:1"
+            - "NaN"
 
       ##################################################################################################################
+      ### Available Aspect Ratios (Mandatory configuration!)
       ### Set all your available aspectRatios (add/remove as you need it in you specific project)
+      ### This is the "pool" you can select from for configurations in defaultCropVariantsConfiguration
       aspectRatios:
         # Open Graph, Facebook, Twitter Image (official @ early 2018)
         "1.91:1":
@@ -71,61 +78,43 @@ imageManipulation:
             title: "LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.free"
             value: 0.0
 
-
       ##################################################################################################################
-      ### Set all your available coverAreas (add/remove as you need it in you specific project)
-      coverAreas:
-        # 1_1_circle can be used for square image (1:1) with CSS `border-radius: 50%` (Tries to cover edges)
-        1_1_circle:
-          - { x: 0.0, y: 0.0, width: 0.25, height: 0.25 }
-          - { x: 0.75, y: 0.0, width: 0.25, height: 0.25 }
-          - { x: 0.0, y: 0.75, width: 0.25, height: 0.25 }
-          - { x: 0.75, y: 0.75, width: 0.25, height: 0.25 }
-        # Cover lower third of image
-        lower_third:
-          - { x: 0.0, y: 0.67, width: 1.0, height: 0.33 }
-
-
-      ##################################################################################################################
-      ### Set all your available coverAreas (add/remove as you need it in you specific project)
+      ### Define default crop areas (Mandatory configuration!)
       cropAreas:
         default:
           x: 0.0
           y: 0.0
           width: 1.0
           height: 1.0
-        "0.75":
+        mobile:
           x: 0.125
           y: 0.125
           width: 0.75
           height: 0.75
-        "0.5":
-          x: 0.25
-          y: 0.25
-          width: 0.5
-          height: 0.5
-        "0.25":
-          x: 0.375
-          y: 0.375
-          width: 0.25
-          height: 0.2
-
 
       ##################################################################################################################
-      ### Set all your available focusAreas (add/remove as you need it in you specific project)
+      ### Define coverAreas (Optional configuration. Omit the coverAreas key if no cover areas needed)
+      coverAreas:
+        # 1_1_circle can be used for square image (1:1) with CSS `border-radius: 50%` (Tries to cover edges)
+        default:
+          - { x: 0.0, y: 0.0, width: 0.25, height: 0.25 }
+          - { x: 0.75, y: 0.0, width: 0.25, height: 0.25 }
+          - { x: 0.0, y: 0.75, width: 0.25, height: 0.25 }
+          - { x: 0.75, y: 0.75, width: 0.25, height: 0.25 }
+        # Cover lower third of image
+        mobile:
+          - { x: 0.0, y: 0.67, width: 1.0, height: 0.33 }
+
+      ##################################################################################################################
+      ### Define focusAreas (Optional configuration. Omit the focusAreas key if no focus areas needed)
       focusAreas:
-        "0.75":
+        "default":
           x: 0.125
           y: 0.125
           width: 0.75
           height: 0.75
-        "0.5":
+        "mobile":
           x: 0.25
           y: 0.25
           width: 0.5
           height: 0.5
-        "0.25":
-          x: 0.375
-          y: 0.375
-          width: 0.25
-          height: 0.25

--- a/Configuration/TCA/Overrides/sys_file_reference.php
+++ b/Configuration/TCA/Overrides/sys_file_reference.php
@@ -5,7 +5,9 @@ use JosefGlatz\CropVariantsBuilder\Builder;
 use JosefGlatz\CropVariantsBuilder\CropVariant;
 use JosefGlatz\CropVariantsBuilder\Defaults\AspectRatio;
 use JosefGlatz\CropVariantsBuilder\Defaults\Configuration;
+use JosefGlatz\CropVariantsBuilder\Defaults\CoverArea;
 use JosefGlatz\CropVariantsBuilder\Defaults\CropArea;
+use JosefGlatz\CropVariantsBuilder\Defaults\FocusArea;
 
 call_user_func(
     static function ($extKey, $table) {
@@ -28,7 +30,9 @@ call_user_func(
             foreach ($defaults as $key => $config) {
                 $defaultCrop = $defaultCrop->addCropVariant(
                     CropVariant::create($key)
-                        ->setCropArea(CropArea::get())
+                        ->setCropArea(CropArea::get($key))
+                        ->setFocusArea(FocusArea::get($key))
+                        ->addCoverAreas(CoverArea::get([$key]))
                         ->addAllowedAspectRatios(AspectRatio::get($config['aspectRatios']))
                         ->get()
                 );


### PR DESCRIPTION
I added some missing code to make focus and cover areas functional. Out of the box the EXT:cropvariantsbuilder broke the crop functionality in the backend, because the cropvariantsbuilder forced a configuration of focus and cover areas with the yaml but because of missing implementation both configurations ended in an empty array, which killed the crop functionality. If someone uses the builder programmatically in the TCA, this does not take place, because then the configuration of the yaml file gets overwritten.
My contribution is an approach to make focus and cover areas optional and to implement their functionality.