### PR TITLE
[BUGFIX] Fix implicit null parameter

### DIFF
--- a/Classes/Builder.php
+++ b/Classes/Builder.php
@@ -175,7 +175,7 @@ class Builder
      * @return self
      * @throws \Exception
      */
-    public function persistToTca(bool $force = false, int $customChildType = null, string $imageManipulationField = self::DEFAULT_IMAGE_MANIPULATION_FIELD): self
+    public function persistToTca(bool $force = false, ?int $customChildType = null, string $imageManipulationField = self::DEFAULT_IMAGE_MANIPULATION_FIELD): self
     {
         if (empty($this->cropVariants)) {
             throw new \RuntimeException(


### PR DESCRIPTION
Mark parameters as nullable explicitly. This fixes deprecation warnings with PHP 8.4.