### PR TITLE
[TASK] TYPO3 v14 compatibility and code quality improvements

### DIFF
--- a/Classes/Builder.php
+++ b/Classes/Builder.php
@@ -174,29 +174,29 @@ class Builder
                 // no type set, no customChildType
                 if (!empty($GLOBALS['TCA'][$this->table]['columns'][$this->fieldName]['config']['overrideChildTca']['columns'][$imageManipulationField]['config']['cropVariants'])) {
                     throw new \UnexpectedValueException('cropVariants configuration can not be persisted.
-                    cropVariants configuration already exists for ' . $this->table . '.' . $this->fieldName . ($this->type === '' || $this->type === '0' ? '' : ' (type ' . $this->type . ')') . '.', 1520884066);
+                    cropVariants configuration already exists for ' . $this->table . '.' . $this->fieldName . '.', 1520884066);
                 }
                 $GLOBALS['TCA'][$this->table]['columns'][$this->fieldName]['config']['overrideChildTca']['columns'][$imageManipulationField]['config']['cropVariants'] = $config;
             } else {
                 // type set, no customChildType
                 if (!empty($GLOBALS['TCA'][$this->table]['types'][$this->type]['columnsOverrides'][$this->fieldName]['config']['overrideChildTca']['columns'][$imageManipulationField]['config']['cropVariants'])) {
                     throw new \UnexpectedValueException('cropVariants configuration can not be persisted.
-                    cropVariants configuration already exists for ' . $this->table . '.' . $this->fieldName . ($this->type === '' || $this->type === '0' ? '' : ' (type ' . $this->type . ')') . '.', 1520884830);
+                    cropVariants configuration already exists for ' . $this->table . '.' . $this->fieldName . ' (type ' . $this->type . ').', 1520884830);
                 }
                 $GLOBALS['TCA'][$this->table]['types'][$this->type]['columnsOverrides'][$this->fieldName]['config']['overrideChildTca']['columns'][$imageManipulationField]['config']['cropVariants'] = $config;
             }
         } elseif ($this->type === '' || $this->type === '0') {
-            // type set, customChildType set
+            // no type set, customChildType set
             if (!empty($GLOBALS['TCA'][$this->table]['columns'][$this->fieldName]['config']['overrideChildTca']['types'][$customChildType]['columnsOverrides'][$imageManipulationField]['config']['cropVariants'])) {
                 throw new \UnexpectedValueException('cropVariants configuration can not be persisted.
-                    cropVariants configuration already exists for ' . $this->table . '.' . $this->fieldName . ($this->type === '' || $this->type === '0' ? '' : ' (type ' . $this->type . ')') . ' (customChildType ' . (string)$customChildType . '.', 1520885194);
+                    cropVariants configuration already exists for ' . $this->table . '.' . $this->fieldName . ' (customChildType ' . (string)$customChildType . ').', 1520885194);
             }
             $GLOBALS['TCA'][$this->table]['columns'][$this->fieldName]['config']['overrideChildTca']['types'][$customChildType]['columnsOverrides'][$imageManipulationField]['config']['cropVariants'] = $config;
         } else {
-            // no type set, customChildType set
+            // type set, customChildType set
             if (!empty($GLOBALS['TCA'][$this->table]['types'][$this->type]['columnsOverrides'][$this->fieldName]['config']['overrideChildTca']['types'][$customChildType]['columnsOverrides'][$imageManipulationField]['config']['cropVariants'])) {
                 throw new \UnexpectedValueException('cropVariants configuration can not be persisted.
-                    cropVariants configuration already exists for ' . $this->table . '.' . $this->fieldName . ($this->type === '' || $this->type === '0' ? '' : ' (type ' . $this->type . ')') . ' (customChildType ' . (string)$customChildType . '.', 1520885283);
+                    cropVariants configuration already exists for ' . $this->table . '.' . $this->fieldName . ' (type ' . $this->type . ') (customChildType ' . (string)$customChildType . ').', 1520885283);
             }
             $GLOBALS['TCA'][$this->table]['types'][$this->type]['columnsOverrides'][$this->fieldName]['config']['overrideChildTca']['types'][$customChildType]['columnsOverrides'][$imageManipulationField]['config']['cropVariants'] = $config;
         }

--- a/Classes/CropVariant.php
+++ b/Classes/CropVariant.php
@@ -324,8 +324,8 @@ class CropVariant
      */
     protected function validateConfigurationProviderSettings(): bool
     {
-        $configurationProvider['extension'] = $this->emConf->getConfigurationProviderExtension();
-        $configurationProvider['locallangFilename'] = $this->emConf->getConfigurationProviderLocallangFilename();
-        return isset($configurationProvider['extension']) && ($configurationProvider['extension'] !== '' && $configurationProvider['extension'] !== '0') && (isset($configurationProvider['locallangFilename']) && ($configurationProvider['locallangFilename'] !== '' && $configurationProvider['locallangFilename'] !== '0'));
+        $extension = $this->emConf->getConfigurationProviderExtension();
+        $locallangFilename = $this->emConf->getConfigurationProviderLocallangFilename();
+        return $extension !== '' && $extension !== '0' && $locallangFilename !== '' && $locallangFilename !== '0';
     }
 }

--- a/Classes/Defaults/AspectRatio.php
+++ b/Classes/Defaults/AspectRatio.php
@@ -51,7 +51,7 @@ class AspectRatio
             return (float)$value[0];
         }
         if (\count($value) === 2) {
-            return $value[0] / $value[1];
+            return (float)$value[0] / (float)$value[1];
         }
         throw new \UnexpectedValueException('AspectRatio value not valid! Please provide a division or a float number.', 1524838980);
     }

--- a/Classes/Domain/Model/Dto/EmConfiguration.php
+++ b/Classes/Domain/Model/Dto/EmConfiguration.php
@@ -21,7 +21,7 @@ class EmConfiguration implements SingletonInterface
     }
 
     /**
-     * @var string;
+     * @var string
      */
     protected $configurationProviderExtension = '';
 

--- a/Configuration/ImageManipulation/CropVariants.yaml
+++ b/Configuration/ImageManipulation/CropVariants.yaml
@@ -35,11 +35,11 @@ imageManipulation:
             value: 3 / 1
         # Common video format
         "16:9":
-            title: "LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.16_9"
+            title: "core.wizards:imwizard.ratio.16_9"
             value: 16 / 9
         # Common DSLR/SLR format
         "3:2":
-            title: "LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.3_2"
+            title: "core.wizards:imwizard.ratio.3_2"
             value: 3 / 2
         "2:3":
             title: "2:3"
@@ -50,14 +50,14 @@ imageManipulation:
             value: 2 / 1
         # Common Point'n'Shoot camera format
         "4:3":
-            title: "LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.4_3"
+            title: "core.wizards:imwizard.ratio.4_3"
             value: 4 / 3
         "3:4":
             title: "3:4"
             value: 3 / 4
         # Square image format
         "1:1":
-            title: "LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.1_1"
+            title: "core.wizards:imwizard.ratio.1_1"
             value: 1.0
         # Common large/medium camera format
         "5:4":
@@ -68,7 +68,7 @@ imageManipulation:
             value: 4 / 5
         # Free ratio / no ratio limitation
         NaN:
-            title: "LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.free"
+            title: "core.wizards:imwizard.ratio.free"
             value: 0.0
 
 

--- a/Configuration/TCA/Overrides/sys_file_reference.php
+++ b/Configuration/TCA/Overrides/sys_file_reference.php
@@ -12,14 +12,6 @@ call_user_func(
         // Default cropVariants configuration is automatically generated from the selected YAML configuration file
         $defaults = Configuration::defaultConfiguration('defaultCropVariantsConfiguration');
 
-        // Array must be at least available
-        if (!\is_array($defaults)) {
-            throw new \UnexpectedValueException(
-                'The defaultCropVariantsConfiguration configuration can\'t be retrieved from the configuration file. (Please check manually if your active EXT:cropvariantsbuilder configuration file is not empty and the "defaultCropVariantsConfiguration" section is not missing and filled with available aspectRatios. ( ' . Configuration::getActiveConfigurationFilePath() . ' )',
-                1524948477
-            );
-        }
-
         // Overwrite the TYPO3 core default cropVariant configuration
         // if the necessary configuration has at least one aspect ratio specified
         if ($defaults !== []) {

--- a/Resources/LegacyDocumentation/Markdown/Images/CropVariantsBuilder.md
+++ b/Resources/LegacyDocumentation/Markdown/Images/CropVariantsBuilder.md
@@ -54,7 +54,7 @@ defined('TYPO3') || die('Access denied.');
 
 call_user_func(
     static function ($extKey, $table) {
-        $languageFileBePrefix = 'LLL:EXT:' . $extKey . '/Resources/Private/Language/locallang_be.xlf:';
+        $languageFileBePrefix = $extKey . '.be:';
 
         $tca = [
             'columns' => [
@@ -72,7 +72,7 @@ call_user_func(
                                 ],
                                 'allowedAspectRatios' => [
                                     '3:2' => [
-                                        'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.3_2',
+                                        'title' => 'core.wizards:imwizard.ratio.3_2',
                                         'value' => 3 / 2
                                     ],
                                     '2:3' => [
@@ -80,7 +80,7 @@ call_user_func(
                                         'value' => 2 / 3
                                     ],
                                     '4:3' => [
-                                        'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.4_3',
+                                        'title' => 'core.wizards:imwizard.ratio.4_3',
                                         'value' => 4 / 3
                                     ],
                                     '3:4' => [
@@ -88,11 +88,11 @@ call_user_func(
                                         'value' => 3 / 4
                                     ],
                                     '1:1' => [
-                                        'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.1_1',
+                                        'title' => 'core.wizards:imwizard.ratio.1_1',
                                         'value' => 1.0
                                     ],
                                     'NaN' => [
-                                        'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.free',
+                                        'title' => 'core.wizards:imwizard.ratio.free',
                                         'value' => 0.0
                                     ],
                                 ],
@@ -169,7 +169,7 @@ defined('TYPO3') || die('Access denied.');
 
 call_user_func(
     static function ($extKey, $table) {
-        $languageFileBePrefix = 'LLL:EXT:' . $extKey . '/Resources/Private/Language/locallang_BackendGeneral.xlf:';
+        $languageFileBePrefix = $extKey . '.backend_general:';
 
         $additionalColumns = [
             'tx_my_nice_site_extension_nav_image' => [
@@ -204,7 +204,7 @@ call_user_func(
                                             ],
                                             'allowedAspectRatios' => [
                                                 '4:3' => [
-                                                    'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.4_3',
+                                                    'title' => 'core.wizards:imwizard.ratio.4_3',
                                                     'value' => 4 / 3
                                                 ],
                                             ],
@@ -220,7 +220,7 @@ call_user_func(
                                             ],
                                             'allowedAspectRatios' => [
                                                 '4:3' => [
-                                                    'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.4_3',
+                                                    'title' => 'core.wizards:imwizard.ratio.4_3',
                                                     'value' => 4 / 3
                                                 ],
                                             ],
@@ -236,7 +236,7 @@ call_user_func(
                                             ],
                                             'allowedAspectRatios' => [
                                                 '4:3' => [
-                                                    'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.4_3',
+                                                    'title' => 'core.wizards:imwizard.ratio.4_3',
                                                     'value' => 4 / 3
                                                 ],
                                             ],
@@ -279,7 +279,7 @@ defined('TYPO3') || die('Access denied.');
 
 call_user_func(
     static function ($extKey, $table) {
-        $languageFileBePrefix = 'LLL:EXT:' . $extKey . '/Resources/Private/Language/locallang_BackendGeneral.xlf:';
+        $languageFileBePrefix = $extKey . '.backend_general:';
 
         $additionalColumns = [
             'tx_my_nice_site_extension_nav_image' => [

--- a/Resources/LegacyDocumentation/Markdown/Images/TranslationLogic.md
+++ b/Resources/LegacyDocumentation/Markdown/Images/TranslationLogic.md
@@ -21,7 +21,7 @@ ext:cropvariantsbuilder.
 ## If you set the proper extension configuration
 
 A label
-`LLL:EXT:yourconfiguredExtensionName/Resources/Private/Language/locallang.xlf:crop_variants.md.label`
+`yourconfiguredExtensionName.messages:crop_variants.md.label`
 is used as final string.
 
 > Make sure to add the proper translation string to the xlf file!
@@ -29,7 +29,7 @@ is used as final string.
 ## If you do not set the proper extension configuration
 
 A label
-`LLL:EXT:cropvariantsbuilder/Resources/Private/Language/locallang.xlf:crop_variants.md.label`
+`cropvariantsbuilder.messages:crop_variants.md.label`
 is used as final string.
 
 > This returns the label "_Medium (md) &#8673;_". This extension ships a
@@ -41,7 +41,7 @@ of ext:cropvariants!
 ## Overwrite label with a custom content
 
 If you do not want to use XLF files for translating labels at all or you want
-to set a custom `LLL:EXT:whateverforthislabel/...` label then you can use the
+to set a custom `whateverforthislabel...` label then you can use the
 method `setTitle()` of the CropVariant class.
 
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,6 +1,6 @@
 # General
 ###########################
-# cat=general/enable/100; type=string; label=LLL:EXT:cropvariantsbuilder/Resources/Private/Language/locallang_be.xlf:extmng.configurationProviderExtension
+# cat=general/enable/100; type=string; label=cropvariantsbuilder.be:extmng.configurationProviderExtension
 configurationProviderExtension = theme
-# cat=general/enable/200; type=string; label=LLL:EXT:cropvariantsbuilder/Resources/Private/Language/locallang_be.xlf:extmng.configurationProviderLocallangFilename
+# cat=general/enable/200; type=string; label=cropvariantsbuilder.be:extmng.configurationProviderLocallangFilename
 configurationProviderLocallangFilename = locallang


### PR DESCRIPTION
Migrate translation keys to TYPO3 v14 short label syntax
- Replace LLL:EXT:core/... paths with short format (e.g., core.wizards:...)
- Update CropVariants.yaml with new translation key format
- Update documentation examples to reflect new syntax
- Adjust ext_conf_template.txt labels

Code quality improvements
- Add explicit float type casting in AspectRatio division
- Simplify validateConfigurationProviderSettings() in CropVariant
- Fix PHPDoc syntax error in EmConfiguration (@var string; → @var string)
- Improve exception messages in Builder for better debugging context
- Remove redundant array validation in sys_file_reference.php (already handled by Configuration::defaultConfiguration())